### PR TITLE
Replace alert to console warn for e2e purposes

### DIFF
--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -4,7 +4,9 @@ const hasAriesLocalBus = () => ('AriesLocalBus' in window);
 
 const hasParent = () => (('parent' in window) && (window.parent !== window));
 
-const showIncorrectConfigurationAlert = () => { alert(`Environment not supported. ${navigator.userAgent} | AriesLocalBus: ${window.AriesLocalBus}`); }; // eslint-disable-line no-alert
+const showIncorrectConfigurationAlert = () => {
+  console.warn(`Environment not supported. ${navigator.userAgent} | AriesLocalBus: ${window.AriesLocalBus}`); // eslint-disable-line no-console
+};
 
 const publishMessageToBus = (message) => {
   switch (true) {


### PR DESCRIPTION
## Goal

When accessing LAMB with no supported environment, an alert is shown.
This alert can not be handled in e2e tests with Cypress + LAMB and can be replaced by `console.warn` instead.

![](https://media.giphy.com/media/3o6Mbfr22wzruiF4LS/giphy.gif)

