### PR TITLE
Fix scan document topic which expects an object instead of a string

### DIFF
--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -71,7 +71,7 @@ const openEmailInbox = () => publishMessageToBusAndWaitForResponseWithMatchingId
 
 const scanBarcode = () => publishMessageToBusAndWaitForResponseWithMatchingId('scan.barcode');
 
-const scanDocument = (name = 'proofOfAddress') => publishMessageToBusAndWaitForResponseWithMatchingId('scan.document', name);
+const scanDocument = (name = 'proofOfAddress') => publishMessageToBusAndWaitForResponseWithMatchingId('scan.document', { name });
 
 const scanIdentity = (options) => publishMessageToBusAndWaitForResponseWithMatchingId('scan.identity', options);
 


### PR DESCRIPTION
@jasonadt We'll need to update the AriesSDK version in mx-merino for this to work properly