### PR TITLE
Add back the `user.setDefaultRegionId` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Lana B2C Microapp SDK Library Changelog
 
+## v0.7.2
+- Added back `user.region-id` and `view.show-support-icon`
+
 ## v0.6.0
 - Renamed `native.open-email-inbox` to `email.inbox`
 - Renamed `native.is-topic-supported` to `aries.is-topic-supported`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Messages are sent from the webview with a specific event type that the native ap
 | [view.layout](docs/view.md#ariessdksetwebviewlayoutdisplaymode-overlay-stack) | µApp | Set the layout. | |
 | [view.dismiss-icon](docs/view.md#ariessdksetwebviewdismissiconicon-close-back-none) | µApp | Set the icon used to dismiss the view. | |
 | [view.title](docs/view.md#ariessdksetappbartitletitle-string) | µApp | Set the application view title. | |
-| :warning: [view.show-support-icon](docs/view.md#ariessdkshowsupporticonpayload-object) | µApp | Shows or hides the support icon from the UI. | No Op in Android versions >= 1.0.565 |
+| [view.show-support-icon](docs/view.md#ariessdkshowsupporticonpayload-object) | µApp | Shows or hides the support icon from the UI. | |
 | [scan.qr](docs/scan.md#ariessdkscanqrcode) | µApp | Launch a view to scan a QR code | |
 | [scan.barcode](docs/scan.md#ariessdkscanbarcode) | µApp | Launch a view to scan a regular Barcode | |
 | [scan.identity](docs/scan.md#ariessdkscanidentitysettings-object) | µApp | Launch a view to scan an identification document and verify the identity of the user for KYC purposes. | |
@@ -23,6 +23,7 @@ Messages are sent from the webview with a specific event type that the native ap
 | [selfie.enrole](docs/selfie.md#ariessdkcreateselfieuserId-string) | µApp | Launch a view that will be used to enrole a new selfie, usually used in signup. | |
 | [selfie.verify](docs/selfie.md#ariessdkverifyselfieuserId-string) | µApp | Launch a view to verify an existing selfie. |
 | [user.fetch](docs/user.md#ariessdkfetchuser) | µApp | Request data on the current user. | |
+| [user.region-id](docs/user.md#ariessdksetdefaultregionidregionid-string) | µApp | Sets the default region for the current microapp. This will be used as a fallback when the user is logged out. | |
 | [account.fetch](docs/account.md#ariessdkfetchaccount) | µApp | Request data on the currently selected account. | |
 | [transaction.execute](docs/transaction.md#ariessdktransactionexecutesettings-object) | µApp | Show a view that will use to provided attributes to prepare a new transaction to be sent to the server to execute inmediatly. | |
 | [share.text](docs/share.md#ariessdksharetextcontent-string) | µApp | Launch the native sharing components to be able to copy and paste or send the provide text. | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Lana B2C MicroApp SDK for interacting with the Mobile Aries browser.",
   "repository": {
     "type": "git",

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -83,6 +83,8 @@ const sessionToken = () => publishMessageToBusAndWaitForResponseWithMatchingId('
 
 const setAppBarTitle = (title = '') => publishMessageToBusAndWaitForResponseWithMatchingId('view.title', { title });
 
+const setDefaultRegionId = (regionId = '') => publishMessageToBusAndWaitForResponseWithMatchingId('user.region-id', { regionId });
+
 const setWebViewDismissIcon = (icon = 'close') => publishMessageToBusAndWaitForResponseWithMatchingId('view.dismiss-icon', { icon });
 
 const setWebViewLayout = (displayMode = 'stack') => publishMessageToBusAndWaitForResponseWithMatchingId('view.layout', { displayMode });
@@ -112,6 +114,7 @@ const sdk = {
   sessionSign,
   sessionToken,
   setAppBarTitle,
+  setDefaultRegionId,
   setWebViewDismissIcon,
   setWebViewLayout,
   shareText,


### PR DESCRIPTION
Access needs to call the `user.setDefaultRegionId` topic before showing the support button, in order to direct the user to the right FAQ and chat channels. This means we should only show the support button once the user has selected a country, and hide it if the user goes back to the splash or country selection screens.