### PR TITLE
POC feature flag for AriesSDK methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Lana B2C Microapp SDK Library Changelog
 
+## v0.8.1
+ - Added POC of a feature flag for AriesSDK events.
+ 
 ## v0.8.0
 - Added `chat.create-case`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Lana B2C MicroApp SDK for interacting with the Mobile Aries browser.",
   "repository": {
     "type": "git",

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -23,8 +23,8 @@ const publishMessageToBus = (message) => {
 const unwrapResponse = ({ response = {} } = {}) => response;
 
 const publishMessageToBusAndWaitForResponseWithMatchingId = (topic, params = {}) => new Promise((resolve, reject) => {
-  const featureFlags = window.featureFlags ? window.featureFlags : null;
-  const topicFeatureFlag = featureFlags && featureFlags[topic] !== undefined ? featureFlags[topic] : true;
+  const { featureFlags } = window;
+  const topicFeatureFlag = (featureFlags && (featureFlags[topic] !== undefined)) ? featureFlags[topic] : true;
   if (!topicFeatureFlag) {
     resolve({});
     return;

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -24,8 +24,8 @@ const unwrapResponse = ({ response = {} } = {}) => response;
 
 const publishMessageToBusAndWaitForResponseWithMatchingId = (topic, params = {}) => new Promise((resolve, reject) => {
   const featureFlags = window.featureFlags ? window.featureFlags : null;
-  const topicFeatureFlag = featureFlags && featureFlags[topic] !== undefined ? featureFlags[topic] : false;
-  if (topicFeatureFlag) {
+  const topicFeatureFlag = featureFlags && featureFlags[topic] !== undefined ? featureFlags[topic] : true;
+  if (!topicFeatureFlag) {
     resolve({});
     return;
   }

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -23,6 +23,12 @@ const publishMessageToBus = (message) => {
 const unwrapResponse = ({ response = {} } = {}) => response;
 
 const publishMessageToBusAndWaitForResponseWithMatchingId = (topic, params = {}) => new Promise((resolve, reject) => {
+  const featureFlags = window.featureFlags ? window.featureFlags : null;
+  const topicFeatureFlag = featureFlags && featureFlags[topic] !== undefined ? featureFlags[topic] : false;
+  if (topicFeatureFlag) {
+    resolve({});
+    return;
+  }
   const payload = {
     id: uuidv4(),
     topic,


### PR DESCRIPTION
## Goals

We need a feature flag to enable/disable analytics in production based on a feature flag. 

## Description
The value of this "feature flags" are going to be provided by native inside `window.featureFlags`. This feature flag will contain the `event` as a key of the feature flag and a boolean value to enable this feature or not.

The implementation checks for this feature flag. However if it does not exist, code executes as normal. If feature flag is present and feature is disabled (`false` value of the feature flag), resolved promise is returned due to not to break anything in the FE.

## Extra

Not tested yet ( dealing with it to test it in `local + LAMB`  & `staging + LAMB` soon )
