### PR TITLE
Add temporary staging analytics event call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Lana B2C Microapp SDK Library Changelog
 
+## v0.8.2
+ - (temporary) Added analytics.eventStaging to only trigger analytics in staging environment
+ 
 ## v0.8.1
  - Added POC of a feature flag for AriesSDK events.
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Lana B2C MicroApp SDK for interacting with the Mobile Aries browser.",
   "repository": {
     "type": "git",

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -23,12 +23,6 @@ const publishMessageToBus = (message) => {
 const unwrapResponse = ({ response = {} } = {}) => response;
 
 const publishMessageToBusAndWaitForResponseWithMatchingId = (topic, params = {}) => new Promise((resolve, reject) => {
-  const { featureFlags } = window;
-  const topicFeatureFlag = (featureFlags && (featureFlags[topic] !== undefined)) ? featureFlags[topic] : true;
-  if (!topicFeatureFlag) {
-    resolve({});
-    return;
-  }
   const payload = {
     id: uuidv4(),
     topic,
@@ -61,7 +55,7 @@ const setupAriesOrParentMessageBus = () => {
 };
 setupAriesOrParentMessageBus();
 
-const analyticsEvent = (options) => publishMessageToBusAndWaitForResponseWithMatchingId('analytics.event', options);
+const analyticsEvent = (options) => publishMessageToBusAndWaitForResponseWithMatchingId('analytics.eventStaging', options);
 
 const closeWebView = () => publishMessageToBusAndWaitForResponseWithMatchingId('view.close');
 


### PR DESCRIPTION
## Goal

 - Remove previous POC about feature flags (not working...)
 - Add temporary event to be executed by Aries to only trigger analytics in staging environment.


This is going to be a temporary feature that will be removed once analytics is ready to start tracking in PROD.

![](https://media.giphy.com/media/O6Hw3wYDqzUis/giphy.gif)