### PR TITLE
New method to update user data to be sent to Amplitude

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -17,3 +17,25 @@ Sends events to the different analytics provider configured in the native app.
 | ----- | ---- | ----------- |
 | `eventName` | string | Event name that will be sent to the analytics provider |
 | `properties` | Object | List of `key/value` pairs |
+
+### AriesSDK.udpateAnalyticsUserInfo(event: Object)
+
+```js readonly
+const payload = {
+        fullName: '... ... ...',
+        country: '...',
+        email: '...',
+        phoneNumber: '...',
+        gender: '...',
+};
+AriesSDK.udpateAnalyticsUserInfo(payload);
+```
+Updates user information to be tracked on Analytic events.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+|  fullName | String | Name + Surname1 + Surname2  |
+|  country | String | Selected user country  |
+|  email | String | Email  |
+|  phoneNumber | String | Phone number  |
+|  gender | String | Gender  |

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -22,11 +22,11 @@ Sends events to the different analytics provider configured in the native app.
 
 ```js readonly
 const payload = {
-        fullName: '... ... ...',
-        country: '...',
-        email: '...',
-        phoneNumber: '...',
-        gender: '...',
+        fullName: 'Name Surname1 Surname2',
+        country: 'MX',
+        email: 'emailAddress@email.com',
+        phoneNumber: '1231236666',
+        gender: 'M',
 };
 AriesSDK.udpateAnalyticsUserInfo(payload);
 ```

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -31,6 +31,7 @@ const payload = {
 AriesSDK.udpateAnalyticsUserInfo(payload);
 ```
 Updates user information to be tracked on Analytic events.
+This method MUST be used right before `AriesSDK.analyticsEvent(...)` in order to allow Native to get that new user data to be sent within the analytics payload for those events that required them.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lana/b2c-mapp-sdk",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Lana B2C MicroApp SDK for interacting with the Mobile Aries browser.",
   "repository": {
     "type": "git",

--- a/src/AriesSDK.js
+++ b/src/AriesSDK.js
@@ -57,6 +57,8 @@ setupAriesOrParentMessageBus();
 
 const analyticsEvent = (options) => publishMessageToBusAndWaitForResponseWithMatchingId('analytics.eventStaging', options);
 
+const udpateAnalyticsUserInfo = (options) => publishMessageToBusAndWaitForResponseWithMatchingId('analytics.updateUser', options);
+
 const closeWebView = () => publishMessageToBusAndWaitForResponseWithMatchingId('view.close');
 
 const createSelfie = (userId) => publishMessageToBusAndWaitForResponseWithMatchingId('selfie.enrole', { userId });
@@ -103,6 +105,7 @@ const chatCreateCase = (options) => publishMessageToBusAndWaitForResponseWithMat
 
 const sdk = {
   analyticsEvent,
+  udpateAnalyticsUserInfo,
   closeWebView,
   createSelfie,
   fetchAccount,


### PR DESCRIPTION
## Goals

Some analytic events requires certain user data. That user data can not be (sometimes) get by Native.
This new method send that new user data to Native side to be used to track certain events.

## Description

Method details provided in the analytics documentation. New user values can be sent independently, for example, if fullName has to be sent, the rest of the possible values can be empty.

![](https://media.giphy.com/media/9HvfMzSvhM9K8/giphy.gif)
